### PR TITLE
Carousel missing type script

### DIFF
--- a/clif-codes/src/app/components/Carousel.tsx
+++ b/clif-codes/src/app/components/Carousel.tsx
@@ -32,6 +32,10 @@ const mySkills: Skill[] = [
     icon: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/nodejs/nodejs-original.svg",
   },
   {
+    technology: "TypeScript",
+    icon: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+  },
+  {
     technology: "HTML",
     icon: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/html5/html5-original.svg",
   },
@@ -42,10 +46,6 @@ const mySkills: Skill[] = [
   {
     technology: "Tailwind",
     icon: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/tailwindcss/tailwindcss-original.svg",
-  },
-  {
-    technology: "Firebase",
-    icon: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/firebase/firebase-original.svg",
   },
   {
     technology: "Supabase",

--- a/clif-codes/src/app/icon.tsx
+++ b/clif-codes/src/app/icon.tsx
@@ -1,0 +1,49 @@
+import { ImageResponse } from 'next/og'
+import { Great_Vibes } from 'next/font/google';
+ 
+// Route segment config
+export const runtime = 'edge'
+ 
+//font
+const great_vibes = Great_Vibes({
+    subsets: ['latin'],
+    weight: '400',
+    display: 'swap',
+    variable: '--font-great-vibes'
+})
+
+// Image metadata
+export const size = {
+  width: 32,
+  height: 32,
+}
+export const contentType = 'image/png'
+ 
+// Image generation
+export default function Icon() {
+  return new ImageResponse(
+    (
+      // ImageResponse JSX element
+      <div
+        style={{
+          fontSize: 28,
+          background: 'transparent',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+        }}
+      >
+        <p>C</p><p style={{color:'skyblue'}}>C</p>
+      </div>
+    ),
+    // ImageResponse options
+    {
+      // For convenience, we can re-use the exported icons size metadata
+      // config to also set the ImageResponse's width and height.
+      ...size,
+    }
+  )
+}


### PR DESCRIPTION
I added the TypeScript Icon to the Carousel as requested in Issue #11 .

In doing this, I deleted the firebase icon as I don't really use it anymore. I prefer the open source variation ' Supabase ' over firebase lately. 

Following up, I also made a minor undocumented change of the favicon. It now shows 'CC' instead of the next.js stock favicon. 

Ready for merge 👍 