### PR TITLE
started adding service pages, lots of changes here

### DIFF
--- a/clif-codes/src/app/components/Carousel.tsx
+++ b/clif-codes/src/app/components/Carousel.tsx
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import React from 'react';
 import { Italianno } from 'next/font/google';
+import Image from 'next/image';
 
 const italianno = Italianno({
   subsets: ['latin'],
@@ -59,9 +60,11 @@ export default function Carousel() {
       <div className="flex">
         {mySkills.map((skill: Skill) => (
           <div key={randomUUID()} className="w-48 flex-none px-2">
-            <img
-              className="h-20 w-20 m-auto items-center content-center"
+            <Image
+              className="m-auto items-center content-center"
               src={skill.icon}
+              height={80}
+              width={80}
               alt={`Skill possessed by Clif, icon representing skill of: ${skill.technology}`}
             />
             <p className="font-sans text-1xl m-auto mt-[1rem] items-center content-center w-fit">{skill.technology}</p>
@@ -69,8 +72,10 @@ export default function Carousel() {
         ))}
         {mySkills.map((skill: Skill) => (
           <div key={randomUUID()} className="w-48 flex-none px-2">
-            <img
-              className="h-20 w-20 m-auto items-center content-center"
+            <Image
+              height={80}
+              width={80}
+              className="m-auto items-center content-center"
               src={skill.icon}
               alt={`Skill possessed by Clif, icon representing skill of: ${skill.technology}`}
             />

--- a/clif-codes/src/app/components/Footer.tsx
+++ b/clif-codes/src/app/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Footer = () => {
   return (
-    <footer className="py-6 sm:hidden">
+    <footer className="pt-16 sm:hidden">
       <div className="container mx-auto">
         <div className="flex justify-between content-center">
           {/* Column 1: Logo and copyright */}

--- a/clif-codes/src/app/components/Header.tsx
+++ b/clif-codes/src/app/components/Header.tsx
@@ -12,7 +12,7 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   ChevronDownIcon,
-  PhoneIcon,
+  BarsArrowDownIcon,
   ClipboardIcon,
 } from "@heroicons/react/20/solid";
 import { usePathname } from "next/navigation";
@@ -21,39 +21,39 @@ const products = [
   {
     name: "Analytics",
     description: "Get a better understanding of your traffic",
-    href: "/#services",
+    href: "/services/metrics-service",
     icon: ChartPieIcon,
   },
   {
     name: "UI Design",
     description: "Bring your site to life with cutting-edge UI development",
-    href: "/#services",
+    href: "/services/ui-service",
     icon: CursorArrowRaysIcon,
   },
   {
     name: "User Authentication Services",
     description: "Allow users sign in or create accounts",
-    href: "/#services",
+    href: "/services/userAuth-service",
     icon: FingerPrintIcon,
   },
   {
     name: "Database Setup & Management",
     description:
       "Manage your data & information in a safe and secure environment",
-    href: "/#services",
+    href: "/services/database-service",
     icon: SquaresPlusIcon,
   },
   {
     name: "Email & Subscription Services",
     description:
       "Get set up with newsletter & subscription services for your users",
-    href: "/#services",
+    href: "/services/newsletter-service",
     icon: ArrowPathIcon,
   },
 ];
 const callsToAction = [
   { name: "Terms of Service", href: "/terms", icon: ClipboardIcon },
-  { name: "Contact Clif", href: "/contact", icon: PhoneIcon },
+  { name: "All Services", href: "/#services", icon: BarsArrowDownIcon },
 ];
 
 function classNames(...classes) {
@@ -163,19 +163,6 @@ export default function Header() {
             {pathname === "/schedule" ? "Home Page" : "Schedule Consultation"}
           </a>
           <a
-            href="https://clif.codes"
-            target="_blank"
-            className="text-base font-semibold leading-6 text-gray-900"
-          >
-            Portfolio
-          </a>
-          <a
-            href="#"
-            className="text-base font-semibold leading-6 text-gray-900"
-          >
-            Testimonials
-          </a>
-          <a
             href={pathname === "/contact" ? "/" : "/contact"}
             className="text-base font-semibold leading-6 text-gray-900"
           >
@@ -244,19 +231,6 @@ export default function Header() {
                   {pathname === "/schedule"
                     ? "Home Page"
                     : "Schedule Consultation"}
-                </a>
-
-                <a
-                  href="#"
-                  className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold leading-7 text-gray-900 hover:bg-gray-50"
-                >
-                  Portfolio
-                </a>
-                <a
-                  href="#"
-                  className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold leading-7 text-gray-900 hover:bg-gray-50"
-                >
-                  Testimonials
                 </a>
                 <a
                   href={pathname === "/contact" ? "/" : "/contact"}

--- a/clif-codes/src/app/components/Hero.tsx
+++ b/clif-codes/src/app/components/Hero.tsx
@@ -11,24 +11,28 @@ const features = [
     description:
       "Full application design & individual component designs / templates",
     icon: ComputerDesktopIcon,
+    href: "/services/ui-service",
   },
   {
     name: "Full Stack Solutions",
     description:
       "From static single page web applications to dynamic with a database and user management",
     icon: CommandLineIcon,
+    href: "/services/dynamic-service",
   },
   {
     name: "Newsletter & Email Services",
     description:
       "Set up your users to get your latest updates and information, automated through email",
     icon: InboxIcon,
+    href: "/services/newsletter-service",
   },
   {
     name: "User Authentication & Management",
     description:
       "Bring account creation to your users and manage account features / tools",
     icon: FingerPrintIcon,
+    href: "/services/userAuth-service",
   },
 ];
 
@@ -63,19 +67,20 @@ export default function Hero() {
                 <dd className="mt-2 text-base leading-7 text-gray-600">
                   {feature.description}
                 </dd>
+                <a href={feature.href} className="text-sm text-sky-400 hover:text-sky-600">View Service</a>
               </div>
             ))}
           </dl>
           <div className="flex justify-evenly pt-20">
             <a
               href="/schedule"
-              className="transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-2 border-white p-4 rounded-lg"
+              className="transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-[0.12rem] border-black p-4 rounded-lg"
             >
               Schedule
             </a>
             <a
               href="/contact"
-              className="transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-2 border-white p-4 rounded-lg"
+              className="transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-[0.12rem] border-black p-4 rounded-lg"
             >
               Contact
             </a>

--- a/clif-codes/src/app/components/Hero.tsx
+++ b/clif-codes/src/app/components/Hero.tsx
@@ -1,69 +1,87 @@
-import { InboxIcon, ComputerDesktopIcon, FingerPrintIcon, CommandLineIcon } from '@heroicons/react/24/outline'
+import {
+  InboxIcon,
+  ComputerDesktopIcon,
+  FingerPrintIcon,
+  CommandLineIcon,
+} from "@heroicons/react/24/outline";
 
 const features = [
   {
-    name: 'UI Design Services',
+    name: "UI Design Services",
     description:
-      'Full application design & individual component designs / templates',
+      "Full application design & individual component designs / templates",
     icon: ComputerDesktopIcon,
   },
   {
-    name: 'Full Stack Solutions',
+    name: "Full Stack Solutions",
     description:
-      'From static single page web applications to dynamic with a database and user management',
+      "From static single page web applications to dynamic with a database and user management",
     icon: CommandLineIcon,
   },
   {
-    name: 'Newsletter & Email Services',
+    name: "Newsletter & Email Services",
     description:
-      'Set up your users to get your latest updates and information, automated through email',
+      "Set up your users to get your latest updates and information, automated through email",
     icon: InboxIcon,
   },
   {
-    name: 'User Authentication & Management',
+    name: "User Authentication & Management",
     description:
-      'Bring account creation to your users and manage account features / tools',
+      "Bring account creation to your users and manage account features / tools",
     icon: FingerPrintIcon,
   },
-]
+];
 
 export default function Hero() {
   return (
     <div className="bg-white py-8 sm:py-4">
       <div className="mx-auto w-7/12 sm:w-[100%] px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl lg:text-center">
-          <h2 className="text-base font-semibold leading-7 text-sky-400">Deploy faster with quality solutions</h2>
-          <p className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-            Satisfaction guarenteed
-          </p>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
-            Check out some of our solutions below for a glimpse at what we can do for you 
-          </p>
-        </div>
+  <div className="mx-auto max-w-2xl lg:text-center">
+    <h2 className="text-base font-semibold leading-7 text-sky-400">
+      Veteran owned & operated
+    </h2>
+    <p className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+    Elevate Your Strategy with Premium Solutions
+    </p>
+    <p className="mt-6 text-lg leading-8 text-gray-600">
+      Delivering high quality, performant results. View some of our solutions below
+    </p>
+  </div>
         <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-4xl">
           <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-10 lg:max-w-none lg:grid-cols-2 lg:gap-y-16">
             {features.map((feature) => (
               <div key={feature.name} className="relative pl-16">
                 <dt className="text-base font-semibold leading-7 text-gray-900">
                   <div className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg bg-sky-400">
-                    <feature.icon className="h-6 w-6 text-white" aria-hidden="true" />
+                    <feature.icon
+                      className="h-6 w-6 text-white"
+                      aria-hidden="true"
+                    />
                   </div>
                   {feature.name}
                 </dt>
-                <dd className="mt-2 text-base leading-7 text-gray-600">{feature.description}</dd>
+                <dd className="mt-2 text-base leading-7 text-gray-600">
+                  {feature.description}
+                </dd>
               </div>
             ))}
           </dl>
-          <div className='flex justify-evenly pt-20'>
-            <a href="/schedule" className='transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-2 border-white p-4 rounded-lg'>
+          <div className="flex justify-evenly pt-20">
+            <a
+              href="/schedule"
+              className="transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-2 border-white p-4 rounded-lg"
+            >
               Schedule
             </a>
-            <a href="/contact" className='transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-2 border-white p-4 rounded-lg'>
+            <a
+              href="/contact"
+              className="transition duration-300 ease-in-out bg-sky-400 text-white hover:bg-sky-600 border-2 border-white p-4 rounded-lg"
+            >
               Contact
             </a>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/clif-codes/src/app/components/Mockups.tsx
+++ b/clif-codes/src/app/components/Mockups.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 export default function Mockups() {
   return (
     <section id="mockup" className="w-[80%] mx-auto">
+      <h4 className="text-center text-3xl font-bold sm:text-left sm:px-[1rem]">Responsive solutions for any device</h4>
       <div className="flex flex-row justify-evenly mx-auto flex-wrap">
         <Image
           src="/desktopMockup.svg"

--- a/clif-codes/src/app/components/ServiceInfo.tsx
+++ b/clif-codes/src/app/components/ServiceInfo.tsx
@@ -6,26 +6,63 @@ interface Service {
   service: string;
   imageSrc: string;
   description: string;
+  description2: string | null;
   technologies: string[] | null;
 }
 
 export default function ServiceInfo(service: Service) {
   return (
-    <div>
+    <div className="h-[100%]">
       <Header />
-      <div className="flex">
-        <Image
-          src={service.imageSrc}
-          alt={`Clip art image representation for ${service.service} service`}
-          height={100}
-          width={100}
-          className="rounded-xl"
-        />
-        <h1>{service.service}</h1>
+      <div className="flex items-center justify-center mt-8">
+        <div className="flex items-center">
+          <div className="rounded-full overflow-hidden mr-4">
+            <Image
+              src={service.imageSrc}
+              alt={`Clip art image representation for ${service.service} service`}
+              height={100}
+              width={100}
+              className="rounded-full"
+            />
+          </div>
+          <h1 className="text-2xl font-bold">{service.service}</h1>
+        </div>
       </div>
-      <div className="flex flex-col">
-        <h4>What is {`${service.service}`}?</h4>
-        <p>{service.description}</p>
+      <div className="border-b border-gray-300 mt-4"></div>
+      <div className="mt-8 px-4 min-h-[48vh] leading-10 text-lg w-8/12 mx-auto sm:w-full sm:mx-0">
+        <div className="flex flex-col">
+          <div className="flex my-4 border-2 w-fit rounded-lg px-4">
+            <a href="/" className="items-center content-center m-auto mr-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-6 h-6"
+              >
+                <path d="M11.47 3.841a.75.75 0 0 1 1.06 0l8.69 8.69a.75.75 0 1 0 1.06-1.061l-8.689-8.69a2.25 2.25 0 0 0-3.182 0l-8.69 8.69a.75.75 0 1 0 1.061 1.06l8.69-8.689Z" />
+                <path d="m12 5.432 8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 0-.75-.75h-3a.75.75 0 0 0-.75.75V21a.75.75 0 0 1-.75.75H5.625a1.875 1.875 0 0 1-1.875-1.875v-6.198a2.29 2.29 0 0 0 .091-.086L12 5.432Z" />
+              </svg>
+            </a>
+            <span>{"->"}</span>
+            <a href="/#services" className="mx-2">Services</a>
+            <span>{"->"}</span>
+            <p className="mx-2 text-sky-400 underline">{service.service}</p>
+          </div>
+          <h4 className="text-xl font-bold">What is {service.service}?</h4>
+          <p className="mt-4 sm:mt-8">{service.description}</p>
+          <p className="mt-4 sm:mt-8">{service.description2}</p>
+          
+          <h4 className="text-xl font-bold my-8">Technologies Used:</h4>
+          <div className="flex flex-wrap justify-start">
+            {service.technologies.map((technology) => {
+              return (
+                <ul key={technology}>
+                  <li className="w-fit mr-8">{technology}</li>
+                </ul>
+              );
+            })}
+          </div>
+        </div>
       </div>
       <Footer />
     </div>

--- a/clif-codes/src/app/components/ServiceInfo.tsx
+++ b/clif-codes/src/app/components/ServiceInfo.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+import Header from "./Header";
+import Footer from "./Footer";
+
+interface Service {
+  service: string;
+  imageSrc: string;
+  description: string;
+  technologies: string[] | null;
+}
+
+export default function ServiceInfo(service: Service) {
+  return (
+    <div>
+      <Header />
+      <div className="flex">
+        <Image
+          src={service.imageSrc}
+          alt={`Clip art image representation for ${service.service} service`}
+          height={100}
+          width={100}
+          className="rounded-xl"
+        />
+        <h1>{service.service}</h1>
+      </div>
+      <div className="flex flex-col">
+        <h4>What is {`${service.service}`}?</h4>
+        <p>{service.description}</p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/clif-codes/src/app/components/Services.tsx
+++ b/clif-codes/src/app/components/Services.tsx
@@ -8,7 +8,7 @@ export default function Services() {
         Core Services
       </h4>
       <div className="grid grid-cols-3 gap-4 w-7/12 mx-auto my-[3rem] md:flex md:flex-col md:w-[60%] sm:flex sm:flex-col sm:w-[90%]">
-        <div id="ui" className="text-center py-4 rounded-lg hover:shadow-xl sm:text-left overflow-hidden">
+        <a href="/services/ui-service" id="ui" className="text-center py-4 rounded-lg hover:shadow-xl sm:text-left overflow-hidden">
           <Image
             src={"/uiDevelopment1.svg"}
             alt="Phone screen with a thumbs up over top of some UI"
@@ -24,8 +24,8 @@ export default function Services() {
             services. From designing simple components to full-on component
             libraries, I will surely make your page pop.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/static-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/static1.svg"}
             alt="A website with a couple of different static pages surrounding it"
@@ -41,8 +41,8 @@ export default function Services() {
             efficiently. Count on me to bring your vision to life with precision
             and creativity and responsiveness.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/dynamic-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/dynamic.svg"}
             alt="A crane holding up a frame of a website while some machinery works on the web page"
@@ -58,8 +58,8 @@ export default function Services() {
             services will transform your ideas into dynamic, feature-rich
             applications that captivate your audience.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/database-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/database.svg"}
             alt="Two machines that resemble humans with robot heads dancing gleefully as money prints from their mouths while the stocks rise on the screen in the back of the room"
@@ -77,8 +77,8 @@ export default function Services() {
             optimize your database performance and streamline your data
             management processes.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/userAuth-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/userAuth.svg"}
             alt="A user sitting at a control center with an eye monocle on, focused for what they are doing"
@@ -96,8 +96,8 @@ export default function Services() {
             solutions that prioritize security and usability, enhancing the
             overall user experience.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/newsletter-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/newsletter.svg"}
             alt="Calendar, next to a screen with some rising stocks and piles of coins with $$"
@@ -115,8 +115,8 @@ export default function Services() {
             effectively communicate with your subscribers and grow your brand
             presence.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/metrics-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/metrics.svg"}
             alt="Cash register printing off a long receipt. The screen on the cash register resembles a surprised/sad face from being overworked"
@@ -133,8 +133,8 @@ export default function Services() {
             providing actionable recommendations, I will help you optimize your
             online presence and drive results.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/advocate-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/devadvocate.svg"}
             alt="A robot teaching a class on what appears to be algebra. The robot is pointing a stick at a chalkboard that contains some different graphs. School setting."
@@ -150,8 +150,8 @@ export default function Services() {
             that I know, from principals of UI/UX design to Object Oriented
             Programming. I can help you to become a better developer.
           </p>
-        </div>
-        <div className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
+        </a>
+        <a href="/services/random-service" className="text-center py-4 rounded-lg hover:shadow-lg sm:text-left overflow-hidden">
           <Image
             src={"/1off.svg"}
             alt="Website shattering while someone at a control desk is trying something to fix it"
@@ -168,7 +168,7 @@ export default function Services() {
             Whether it be a custom feature or a technical hurdle, I am here to
             deliver bespoke solutions that exceed expectations.
           </p>
-        </div>
+        </a>
       </div>
     </section>
   );

--- a/clif-codes/src/app/contact/page.tsx
+++ b/clif-codes/src/app/contact/page.tsx
@@ -10,7 +10,7 @@ export default function Contact() {
       <div className="flex justify-around max-w-5xl m-auto pt-[4rem] items-center content-center sm:flex-col sm:pt-[2rem]">
         <div className="flex flex-col justify-between w-[50%] sm:w-[75%]">
           <h2 className="font-bold text-3xl">Point of Contact</h2>
-          <p className="text-gray-500 pt-[2rem]">
+          <p className="pt-[2rem]">
             I am Clif, a passionate web developer of three years. I like to
             solve problems and build new things. I am passionate about AI,
             accessability, & performance. Reach out now to get started working
@@ -32,18 +32,21 @@ export default function Contact() {
       <div className="flex pt-8 pb-[6rem] w-[50%] mx-auto justify-evenly sm:pt-[2rem]">
         <SocialIcon
           bgColor="rgb(56 189 248)"
+          className="transition duration-300 ease-in-out border-[0.12rem] rounded-[100%] border-black hover:scale-125"
           target="_blank"
           url="https://linkedin.com/in/clif-beale"
         />
         <SocialIcon
           bgColor="rgb(56 189 248)"
           href="mailto:cliftonscottbeale@gmail.com"
+          className="transition duration-300 ease-in-out border-[0.12rem] rounded-[100%] border-black hover:scale-125"
           target="_blank"
           network="email"
         />
         <SocialIcon
           bgColor="rgb(56 189 248)"
           href="https://discord.com/users/367069635083894784"
+          className="transition duration-300 ease-in-out border-[0.12rem] rounded-[100%] border-black hover:scale-125 "
           target="_blank"
           network="discord"
         />

--- a/clif-codes/src/app/contact/page.tsx
+++ b/clif-codes/src/app/contact/page.tsx
@@ -28,7 +28,7 @@ export default function Contact() {
           <h4 className="text-sky-400 pt-[1rem]">Freelance Web Developer</h4>
         </div>
       </div>
-      <aside className="text-gray-500 text-center py-8 underline italic">Caution: The buttons below are external links</aside>
+      <aside className="text-gray-500 text-center py-4 underline italic">Note: The buttons below are external links</aside>
       <div className="flex pt-8 pb-[6rem] w-[50%] mx-auto justify-evenly sm:pt-[2rem]">
         <SocialIcon
           bgColor="rgb(56 189 248)"

--- a/clif-codes/src/app/schedule/page.tsx
+++ b/clif-codes/src/app/schedule/page.tsx
@@ -4,7 +4,7 @@ import { InlineWidget } from "react-calendly";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 
-const Schedule = () => {
+export default function Schedule() {
   return (
     <div>
       <Header />
@@ -14,4 +14,3 @@ const Schedule = () => {
   );
 };
 
-export default Schedule;

--- a/clif-codes/src/app/services/advocate-service/page.tsx
+++ b/clif-codes/src/app/services/advocate-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface AdvocateService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const advocateService: AdvocateService = {
+        serviceName: "Developer Advocate",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: null
+    }
+    
+    return <ServiceInfo service={advocateService.serviceName} imageSrc={advocateService.serviceImageLink} description={advocateService.serviceDescription} technologies={advocateService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/advocate-service/page.tsx
+++ b/clif-codes/src/app/services/advocate-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface AdvocateService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const advocateService: AdvocateService = {
         serviceName: "Developer Advocate",
-        serviceDescription: "",
-        serviceImageLink: "",
-        serviceApplicableTechnologies: null
+        serviceDescription: "A developer advocate, especially for a web developer freelancer, is someone who bridges the gap between developers and the products, services, or technologies they use. As a freelancer, this role often involves advocating for tools, frameworks, or platforms that you find valuable in your own work and sharing your experiences and insights with the broader developer community. Developer advocates typically engage in activities such as creating tutorials, writing blog posts, giving talks at conferences or meetups, and participating in online forums or social media discussions to educate and empower other developers.",
+        serviceDescription2: "Furthermore, as a web developer freelancer, being a developer advocate can also mean advocating for yourself and your skills. This may involve promoting your services, showcasing your portfolio of work, and actively networking with potential clients or collaborators. By serving as both an advocate for the tools and technologies you use and for your own expertise and services, you can establish yourself as a trusted authority in the developer community and attract new opportunities for growth and collaboration.",
+        serviceImageLink: "/devadvocate.svg",
+        serviceApplicableTechnologies: ["JavaScript", "TypeScript", "HTML", "CSS", "JavaScript Libraries + frameworks"]
     }
     
-    return <ServiceInfo service={advocateService.serviceName} imageSrc={advocateService.serviceImageLink} description={advocateService.serviceDescription} technologies={advocateService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={advocateService.serviceName} imageSrc={advocateService.serviceImageLink} description={advocateService.serviceDescription} description2={advocateService.serviceDescription2} technologies={advocateService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/database-service/page.tsx
+++ b/clif-codes/src/app/services/database-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface DatabaseService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const databaseService: DatabaseService = {
+        serviceName: "Database Setup and Management",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: ["Supabase", "Firebase", "React", "Next.js", "Node.js", "Prisma"]
+    }
+    
+    return <ServiceInfo service={databaseService.serviceName} imageSrc={databaseService.serviceImageLink} description={databaseService.serviceDescription} technologies={databaseService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/database-service/page.tsx
+++ b/clif-codes/src/app/services/database-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface DatabaseService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const databaseService: DatabaseService = {
         serviceName: "Database Setup and Management",
-        serviceDescription: "",
-        serviceImageLink: "",
+        serviceDescription: "Setting up and managing databases involves creating and organizing digital storage spaces for your application's data. It's like setting up a digital warehouse where you can store all kinds of information your application needs to function, such as user profiles, product details, or messages.",
+        serviceDescription2: "Once the database is set up, it must be managed effectively to ensure its reliability, performance, and security. This entails performing routine maintenance tasks such as database backups, monitoring for performance issues, and optimizing queries to improve efficiency. Additionally, handling tasks related to data migration, schema changes, and user access permissions as the project evolves over time. By maintaining a well-organized and properly managed database, site managers can ensure that their web applications operate smoothly, providing users with a seamless and reliable experience while safeguarding the integrity and security of the stored data.",
+        serviceImageLink: "/database.svg",
         serviceApplicableTechnologies: ["Supabase", "Firebase", "React", "Next.js", "Node.js", "Prisma"]
     }
     
-    return <ServiceInfo service={databaseService.serviceName} imageSrc={databaseService.serviceImageLink} description={databaseService.serviceDescription} technologies={databaseService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={databaseService.serviceName} imageSrc={databaseService.serviceImageLink} description={databaseService.serviceDescription} description2={databaseService.serviceDescription2} technologies={databaseService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/dynamic-service/page.tsx
+++ b/clif-codes/src/app/services/dynamic-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface DynamicService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const dynamicService: DynamicService = {
+        serviceName: "Dynamic Web Application",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: ["React", "Next.js", "Node.js", "Supabase", "Firebase", "Prisma"]
+    }
+    
+    return <ServiceInfo service={dynamicService.serviceName} imageSrc={dynamicService.serviceImageLink} description={dynamicService.serviceDescription} technologies={dynamicService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/dynamic-service/page.tsx
+++ b/clif-codes/src/app/services/dynamic-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface DynamicService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const dynamicService: DynamicService = {
         serviceName: "Dynamic Web Application",
-        serviceDescription: "",
-        serviceImageLink: "",
+        serviceDescription: "Dynamic web application services are web applications that can change and adapt based on user input or data from other sources. They're the interactive parts of the internet that respond to what users do, like filling out a form or clicking a button. Unlike static websites, which always show the same content, dynamic web apps can fetch new information and update the page without needing to reload. They're like virtual assistants that can understand and respond to your needs in real-time.",
+        serviceDescription2: "Creating dynamic web applications involves using more complex technologies like databases, servers, and tools such as Supabase, Firebase, or Prisma (with frameworks like Node.js & Next.js). These applications store and manage data, process requests from users, and generate customized content on the fly. For example, an online store's dynamic web app might show different products to different users based on their browsing history or preferences. Building dynamic web apps requires more coding and setup compared to static sites, but they offer greater flexibility and interactivity, making them ideal for tasks like e-commerce, social networking, and real-time collaboration.",
+        serviceImageLink: "/dynamic.svg",
         serviceApplicableTechnologies: ["React", "Next.js", "Node.js", "Supabase", "Firebase", "Prisma"]
     }
     
-    return <ServiceInfo service={dynamicService.serviceName} imageSrc={dynamicService.serviceImageLink} description={dynamicService.serviceDescription} technologies={dynamicService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={dynamicService.serviceName} imageSrc={dynamicService.serviceImageLink} description={dynamicService.serviceDescription} description2={dynamicService.serviceDescription2} technologies={dynamicService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/metrics-service/page.tsx
+++ b/clif-codes/src/app/services/metrics-service/page.tsx
@@ -1,19 +1,28 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface MetricService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
-    serviceApplicableTechnologies: string[] | null;
+  serviceName: string;
+  serviceDescription: string;
+  serviceDescription2: string;
+  serviceImageLink: string;
+  serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
+  const metricService: MetricService = {
+    serviceName: "Site Metrics Analyzation and Enhancement",
+    serviceDescription: "Site Metrics Analyzation and Enhancement refers to the process of evaluating various metrics related to a website's performance, user engagement, and effectiveness in achieving its goals. As a web developer freelancer, this involves utilizing tools like Google Analytics or other analytics platforms to gather data on key performance indicators such as website traffic, conversion rates, bounce rates, and user demographics. Analyzing these metrics provides valuable insights into how users interact with the website, which pages are performing well, and where there may be areas for improvement.",
+    serviceDescription2: "Once the metrics have been analyzed, the next step is enhancement, which involves making strategic adjustments to the website to improve its performance and effectiveness. This could include optimizing page load times, improving navigation and user experience, enhancing content quality, implementing SEO best practices, and refining calls-to-action. By continuously monitoring site metrics and iteratively enhancing the website based on data-driven insights, web developers can help their clients achieve their business objectives and maximize the impact of their online presence.",
+    serviceImageLink: "/metrics.svg",
+    serviceApplicableTechnologies: ["Google Analytics", "Lighthouse"],
+  };
 
-    const metricService: MetricService = {
-        serviceName: "Site Metrics Analyzation and Enhancement",
-        serviceDescription: "",
-        serviceImageLink: "",
-        serviceApplicableTechnologies: ["Google Analytics"]
-    }
-    
-    return <ServiceInfo service={metricService.serviceName} imageSrc={metricService.serviceImageLink} description={metricService.serviceDescription} technologies={metricService.serviceApplicableTechnologies}/>
+  return (
+    <ServiceInfo
+      service={metricService.serviceName}
+      imageSrc={metricService.serviceImageLink}
+      description={metricService.serviceDescription}
+      description2={metricService.serviceDescription2}
+      technologies={metricService.serviceApplicableTechnologies}
+    />
+  );
 }

--- a/clif-codes/src/app/services/metrics-service/page.tsx
+++ b/clif-codes/src/app/services/metrics-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface MetricService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const metricService: MetricService = {
+        serviceName: "Site Metrics Analyzation and Enhancement",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: ["Google Analytics"]
+    }
+    
+    return <ServiceInfo service={metricService.serviceName} imageSrc={metricService.serviceImageLink} description={metricService.serviceDescription} technologies={metricService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/newsletter-service/page.tsx
+++ b/clif-codes/src/app/services/newsletter-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface EmailService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const emailService: EmailService = {
+        serviceName: "Newsletter and Email Setup",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: null
+    }
+    
+    return <ServiceInfo service={emailService.serviceName} imageSrc={emailService.serviceImageLink} description={emailService.serviceDescription} technologies={emailService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/newsletter-service/page.tsx
+++ b/clif-codes/src/app/services/newsletter-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface EmailService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const emailService: EmailService = {
         serviceName: "Newsletter and Email Setup",
-        serviceDescription: "",
-        serviceImageLink: "",
-        serviceApplicableTechnologies: null
+        serviceDescription: "Newsletters and email subscriptions are essential components of many websites, allowing businesses and organizations to stay connected with their audience and share valuable content, updates, and promotions. As a web developer freelancer, integrating newsletter and email subscription functionality involves implementing features that enable users to sign up to receive periodic emails from the website or company. This typically includes designing and coding user interface elements such as signup forms and subscription buttons, as well as backend processes for storing subscriber information securely in a database.",
+        serviceDescription2: "Once the subscription system is set up, web developer freelancers must implement mechanisms for managing email lists, handling subscriber preferences, and sending out newsletters or marketing emails. Freelancers may also need to ensure compliance with email regulations such as GDPR and CAN-SPAM by providing opt-in/opt-out options, honoring unsubscribe requests, and maintaining transparent data handling practices. By effectively implementing newsletters and email subscriptions, web developer freelancers help their clients build and nurture relationships with their audience, driving engagement and fostering customer loyalty.",
+        serviceImageLink: "/newsletter.svg",
+        serviceApplicableTechnologies: ["To be determined"]
     }
     
-    return <ServiceInfo service={emailService.serviceName} imageSrc={emailService.serviceImageLink} description={emailService.serviceDescription} technologies={emailService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={emailService.serviceName} imageSrc={emailService.serviceImageLink} description={emailService.serviceDescription} description2={emailService.serviceDescription2} technologies={emailService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/random-service/page.tsx
+++ b/clif-codes/src/app/services/random-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface RandomService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const randomService: RandomService = {
         serviceName: "1-Off Solutions",
-        serviceDescription: "",
-        serviceImageLink: "",
-        serviceApplicableTechnologies: null
+        serviceDescription: "A one-off solution, particularly for a web developer freelancer, refers to a custom solution or project that is developed to address a specific need or problem for a client on a one-time basis. This could be a unique website, web application, or feature that is designed and built to meet the client's specific requirements, but is not intended for ongoing maintenance or updates.",
+        serviceDescription2: "These one-off solutions are typically scoped, designed, developed, and delivered as standalone projects, without the expectation of continuous support or future iterations. As a freelancer, my role is to understand the client's needs, propose a tailored solution, execute the project within the agreed-upon timeframe and budget, and deliver a final product that meets or exceeds the client's expectations.",
+        serviceImageLink: "/1off.svg",
+        serviceApplicableTechnologies: ["Depends on the issue"]
     }
     
-    return <ServiceInfo service={randomService.serviceName} imageSrc={randomService.serviceImageLink} description={randomService.serviceDescription} technologies={randomService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={randomService.serviceName} imageSrc={randomService.serviceImageLink} description={randomService.serviceDescription} description2={randomService.serviceDescription2} technologies={randomService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/random-service/page.tsx
+++ b/clif-codes/src/app/services/random-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface RandomService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const randomService: RandomService = {
+        serviceName: "1-Off Solutions",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: null
+    }
+    
+    return <ServiceInfo service={randomService.serviceName} imageSrc={randomService.serviceImageLink} description={randomService.serviceDescription} technologies={randomService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/static-service/page.tsx
+++ b/clif-codes/src/app/services/static-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface StaticService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const staticService: StaticService = {
         serviceName: "Static Web Application",
-        serviceDescription: "",
-        serviceImageLink: "",
+        serviceDescription: "Static web applications are websites where the content is fixed and doesn't change often. They're like posters you hang on the wall—they're already made and don't need to be created each time someone looks at them. These websites are built with basic languages like HTML, CSS, and JavaScript, and they don't need a fancy server to run. They're great for things like showing your portfolio, writing blogs, or displaying information that doesn't change much, because they're simple to build and fast to load.",
+        serviceDescription2: "To make a static web application, you just write the code for what you want the website to look like and do. You don't need to worry about complicated databases or fancy server technology. There are tools that help speed up the process, like templates and frameworks, but at the end of the day, you're just creating a bunch of files that contain your website's content. Once it's ready, you can put it on the internet for everyone to see. Static websites are easy to maintain and can be hosted on different platforms, making them a popular choice for many types of projects.",
+        serviceImageLink: "/static1.svg",
         serviceApplicableTechnologies: ["React", "HTML", "CSS", "Parcel", "TypeScript", "Tailwind CSS"]
     }
     
-    return <ServiceInfo service={staticService.serviceName} imageSrc={staticService.serviceImageLink} description={staticService.serviceDescription} technologies={staticService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={staticService.serviceName} imageSrc={staticService.serviceImageLink} description={staticService.serviceDescription} description2={staticService.serviceDescription2} technologies={staticService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/static-service/page.tsx
+++ b/clif-codes/src/app/services/static-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface StaticService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const staticService: StaticService = {
+        serviceName: "Static Web Application",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: ["React", "HTML", "CSS", "Parcel", "TypeScript", "Tailwind CSS"]
+    }
+    
+    return <ServiceInfo service={staticService.serviceName} imageSrc={staticService.serviceImageLink} description={staticService.serviceDescription} technologies={staticService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/ui-service/page.tsx
+++ b/clif-codes/src/app/services/ui-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface UIService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const uiService: UIService = {
+        serviceName: "UI Development",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: ["Figma", "Adobe PhotoShop", "Canva", "React", "CSS", "HTML", "Tailwind CSS"]
+    }
+    
+    return <ServiceInfo service={uiService.serviceName} imageSrc={uiService.serviceImageLink} description={uiService.serviceDescription} technologies={uiService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/ui-service/page.tsx
+++ b/clif-codes/src/app/services/ui-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface UIService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const uiService: UIService = {
         serviceName: "UI Development",
-        serviceDescription: "",
-        serviceImageLink: "",
+        serviceDescription: "UI development involves crafting the visual elements and interactive features that users encounter when interacting with digital products such as websites, applications, and software interfaces. As a UI developer, your primary focus is on creating intuitive, aesthetically pleasing, and user-friendly interfaces that enhance the overall user experience. This process entails translating design mockups and wireframes into functional and responsive layouts using a combination of HTML, CSS, and JavaScript. UI developers work closely with designers and front-end developers to ensure that the interface design is faithfully implemented and that the user interface seamlessly integrates with the underlying functionality.",
+        serviceDescription2: "In addition to creating visually appealing interfaces, UI development also involves optimizing performance, accessibility, and cross-browser compatibility to ensure a consistent experience across different devices and platforms. This includes implementing responsive design techniques to adapt the interface layout to various screen sizes and resolutions, as well as optimizing asset loading and rendering to minimize load times and enhance usability. UI developers also play a crucial role in ensuring that the interface complies with accessibility standards, making it accessible to users with disabilities and improving overall inclusivity. By combining creativity with technical expertise, UI developers contribute to the success of digital products by delivering engaging and user-centric interfaces that delight users and drive positive interactions.",
+        serviceImageLink: "/uiDevelopment1.svg",
         serviceApplicableTechnologies: ["Figma", "Adobe PhotoShop", "Canva", "React", "CSS", "HTML", "Tailwind CSS"]
     }
     
-    return <ServiceInfo service={uiService.serviceName} imageSrc={uiService.serviceImageLink} description={uiService.serviceDescription} technologies={uiService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={uiService.serviceName} imageSrc={uiService.serviceImageLink} description={uiService.serviceDescription} description2={uiService.serviceDescription2} technologies={uiService.serviceApplicableTechnologies}/>
 }

--- a/clif-codes/src/app/services/userAuth-service/page.tsx
+++ b/clif-codes/src/app/services/userAuth-service/page.tsx
@@ -1,0 +1,19 @@
+import ServiceInfo from "../../components/ServiceInfo";
+
+interface UserAuthService {
+    serviceName: string,
+    serviceDescription: string,
+    serviceImageLink: string,
+    serviceApplicableTechnologies: string[] | null;
+}
+export default function Page() {
+
+    const userAuthService: UserAuthService = {
+        serviceName: "User Authentication and Management",
+        serviceDescription: "",
+        serviceImageLink: "",
+        serviceApplicableTechnologies: ["OAuth", "Supabase", "Firebase", "React", "Next.js", "Node.js", "Prisma"]
+    }
+    
+    return <ServiceInfo service={userAuthService.serviceName} imageSrc={userAuthService.serviceImageLink} description={userAuthService.serviceDescription} technologies={userAuthService.serviceApplicableTechnologies}/>
+}

--- a/clif-codes/src/app/services/userAuth-service/page.tsx
+++ b/clif-codes/src/app/services/userAuth-service/page.tsx
@@ -1,19 +1,21 @@
 import ServiceInfo from "../../components/ServiceInfo";
 
 interface UserAuthService {
-    serviceName: string,
-    serviceDescription: string,
-    serviceImageLink: string,
+    serviceName: string;
+    serviceDescription: string;
+    serviceDescription2: string;
+    serviceImageLink: string;
     serviceApplicableTechnologies: string[] | null;
 }
 export default function Page() {
 
     const userAuthService: UserAuthService = {
         serviceName: "User Authentication and Management",
-        serviceDescription: "",
-        serviceImageLink: "",
+        serviceDescription: "User authentication and management are essential aspects of web development, particularly for freelancers building websites or applications that require user accounts. Authentication involves verifying the identity of users to ensure they are who they claim to be. This process typically involves prompting users to provide credentials, such as a username and password, and then comparing these against stored credentials in a database. As a web developer freelancer, implementing secure authentication mechanisms, such as hashing passwords and using encryption protocols like HTTPS, is crucial to protect user data and prevent unauthorized access.",
+        serviceDescription2: "In addition to authentication, user management encompasses various tasks related to managing user accounts throughout their lifecycle. This includes functionalities such as user registration, login, password reset, and account deletion. Freelancers often implement features to allow users to update their profiles, manage preferences, and control access permissions. Effective user management also involves enforcing security measures like password policies and implementing multi-factor authentication for added security. By prioritizing robust user authentication and management systems, web developer freelancers can build trust with their clients and ensure their web applications are secure and user-friendly.",
+        serviceImageLink: "/userAuth.svg",
         serviceApplicableTechnologies: ["OAuth", "Supabase", "Firebase", "React", "Next.js", "Node.js", "Prisma"]
     }
     
-    return <ServiceInfo service={userAuthService.serviceName} imageSrc={userAuthService.serviceImageLink} description={userAuthService.serviceDescription} technologies={userAuthService.serviceApplicableTechnologies}/>
+    return <ServiceInfo service={userAuthService.serviceName} imageSrc={userAuthService.serviceImageLink} description={userAuthService.serviceDescription} description2={userAuthService.serviceDescription2} technologies={userAuthService.serviceApplicableTechnologies}/>
 }


### PR DESCRIPTION
I started adding the service pages with this PR. 

see Issue #10 

I created a general component <ServicesList /> which takes a few props

- Service
- description
- imagelink
- technologiesApplicable

when clicking on a skill listed on the home page (or in the navbar), the user will be sent to the appropriate service link. On this page, there will be an array of objects, each of which are a different service I will be offering. 

I have already set this up, but have not done several things yet:

- I still need to fill out the description for each service
- Style the ServiceList component
- Add technologies applicable and image links to the services

Right now, I have completed:

- Made services on home page clickable
- Set up proper routing for each service
- Created a general component for each service, so as to save some code
- Cleaned up Hero section and Nav links a bit + made nav links work for services. They now take users to the specific service page

This PR is not yet ready for merge, however 👎 

